### PR TITLE
Home.py

### DIFF
--- a/pages/1_Home.py
+++ b/pages/1_Home.py
@@ -124,3 +124,4 @@ st.markdown("""
 }
 </style>
 """, unsafe_allow_html=True)
+

--- a/pages/2_Projects.py
+++ b/pages/2_Projects.py
@@ -70,4 +70,5 @@ with st.expander("Macroeconomic Dashboard"):
     """, unsafe_allow_html=True)
 
 st.markdown("---")
-st.page_link("pages/1_Home.py", label="← Back to Home", icon="🏠")
+st.page_link("Home.py", label="← Back to Home", icon="🏠")
+

--- a/pages/3_Dashboard.py
+++ b/pages/3_Dashboard.py
@@ -164,4 +164,4 @@ with tabs[3]:
             st.error(f"Error fetching FRED data: {str(e)}. Please check API key.")
 
 st.markdown("---")
-st.page_link("pages/1_Home.py", label="← Back to Home", icon="🏠")
+st.page_link("Home.py", label="← Back to Home", icon="🏠")

--- a/pages/4_Insights.py
+++ b/pages/4_Insights.py
@@ -23,4 +23,4 @@ if st.button("Notify Me"):
         st.warning("Please enter a valid email address")
 
 st.markdown("---")
-st.page_link("pages/1_Home.py", label="← Back to Home", icon="🏠")
+st.page_link("Home.py", label="← Back to Home", icon="🏠")

--- a/pages/5_Contact.py
+++ b/pages/5_Contact.py
@@ -49,4 +49,5 @@ st.subheader("Our Location")
 st.map(pd.DataFrame({'lat': [33.7537], 'lon': [-84.3863]}), zoom=12)
 
 st.markdown("---")
-st.page_link("pages/1_Home.py", label="← Back to Home", icon="🏠")
+st.page_link("Home.py", label="← Back to Home", icon="🏠")
+

--- a/pages/8_Macro_Dashboard.py
+++ b/pages/8_Macro_Dashboard.py
@@ -81,3 +81,4 @@ else:
 
 st.markdown("---")
 st.page_link("pages/2_Projects.py", label="← Back to Projects", icon="📚")
+


### PR DESCRIPTION
Home.py
server.py
vercel.json
requirements.txt
pages/
├── 2_Projects.py
├── 3_Dashboard.py
├── 4_Insights.py
├── 5_Contact.py
├── 6_Options_Analyzer.py
├── 7_Sector_Classifier.py
└── 8_Macro_Dashboard.py

## Summary by Sourcery

Update navigation links in Streamlit pages to point to the relocated Home.py file and ensure files end with a newline

Enhancements:
- Change st.page_link targets from 'pages/1_Home.py' to 'Home.py' across multiple pages

Chores:
- Add trailing newline to several page files for consistent formatting